### PR TITLE
Allow for One-Time parsing of `process.argv`

### DIFF
--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -176,7 +176,9 @@ Vorpal.prototype.parse = function (argv, options) {
         if (err !== undefined && err !== null) {
           throw new Error(err);
         }
-        process.exit(0);
+        if (!options.once) {
+          process.exit(0);
+        }
       });
     }
   }


### PR DESCRIPTION
`New Feature`: One-Time parsing allows to auto restart vorpal with an default `init` command. I opened the [issue #357](https://github.com/dthree/vorpal/issues/357) to describe the situation.

```js
vorpal
   .parse(process.argv, { once: true })
   .show();
```
Just add a new option named `once` to the `vorpal.parse()` options.
